### PR TITLE
Fix editing polygon/polyline/circle in leaflet.draw 0.4.3

### DIFF
--- a/external/leaflet.draw.js
+++ b/external/leaflet.draw.js
@@ -1535,7 +1535,7 @@ L.Edit.Poly = L.Handler.extend({
 	// @method initialize(): void
 	initialize: function (poly, options) {
 
-		this.latlngs = [poly._latlngs];
+		this.latlngs = [poly.getLatLngs()];
 		if (poly._holes) {
 			this.latlngs = this.latlngs.concat(poly._holes);
 		}
@@ -1549,8 +1549,8 @@ L.Edit.Poly = L.Handler.extend({
 	// Compatibility method to normalize Poly* objects
 	// between 0.7.x and 1.0+
 	_defaultShape: function () {
-		if (!L.GeodesicPolyline._flat) { return this._poly._latlngs; }
-		return L.GeodesicPolyline._flat(this._poly._latlngs) ? this._poly._latlngs : this._poly._latlngs[0];
+		if (!L.GeodesicPolyline._flat) { return this._poly.getLatLngs(); }
+		return L.GeodesicPolyline._flat(this._poly.getLatLngs()) ? this._poly.getLatLngs() : this._poly.getLatLngs()[0];
 	},
 
 	_eachVertexHandler: function (callback) {


### PR DESCRIPTION
Retrieve latitude/longitude from call to getLatLngs() rather than accessing the private property _latlngs directly, since L.Geodesic maintains it's own property called .latlngsinit instead when it extends classes.